### PR TITLE
Ignore JSX Expression blocks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,8 +79,14 @@ export default ({ types: t }: { types: BabelTypes }): Visitor => ({
       }
 
       const variable = path.find(( node: NodePath ): NodePath =>
-        node.isVariableDeclarator() || node.isExportDefaultDeclaration(),
+        node.isVariableDeclarator() || node.isExportDefaultDeclaration() ||
+          node.isJSXExpressionContainer(),
       )
+
+      // Ignore JSX elements inside JSX expression blocks
+      if ( t.isJSXExpressionContainer(variable) ) {
+        return
+      }
 
       // Ignore the `if` since I can't come up with a test case to satisfy it.
       /* istanbul ignore if */

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -139,6 +139,43 @@ exports.default = Hello;
 Hello.displayName = \'Hello\';"
 `;
 
+exports[`ignores jsx expression blocks 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var HelloWorld = function HelloWorld() {
+  var content = _react2.default.createElement(
+    'div',
+    null,
+    [1, 2, 3].map(function (n) {
+      return _react2.default.createElement(
+        'h1',
+        null,
+        n
+      );
+    })
+  );
+
+  return _react2.default.createElement(
+    'div',
+    null,
+    content
+  );
+};
+
+HelloWorld.displayName = 'HelloWorld';
+exports.default = HelloWorld;"
+`;
+
 exports[`ignores when displayName is already set on default export function 1`] = `
 "\'use strict\';
 

--- a/test/fixtures/ignore-jsx-expression-blocks/App.js
+++ b/test/fixtures/ignore-jsx-expression-blocks/App.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const HelloWorld = () => {
+  const content = (
+    <div>
+      {
+        [1, 2, 3].map((n) => { return <h1>{n}</h1> })
+      }
+    </div>
+  )
+
+  return <div>{content}</div>
+}
+
+export default HelloWorld

--- a/test/index.js
+++ b/test/index.js
@@ -156,3 +156,9 @@ test(
   snapshotMacro,
   'named-export-block',
 )
+
+test(
+  'ignores jsx expression blocks',
+  snapshotMacro,
+  'ignore-jsx-expression-blocks',
+)


### PR DESCRIPTION
We should ignore JSX elements rendered inside expression blocks
since they do not represent individual components.

Previously the following example would add the `displayName` property to the `content` element:

```js
import React from 'react'

const HelloWorld = () => {
  const content = (
    <div>
      {
        [1, 2, 3].map((n) => { return <h1>{n}</h1> })
      }
    </div>
  )

  return <div>{content}</div>
}

export default HelloWorld
```

This would throw a runtime error since `content` is a react element and cannot be extended with other properties.